### PR TITLE
optional interrupts and more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,3 @@
 idf_component_register(SRCS "ads101x.c"
                     INCLUDE_DIRS "include"
-                    REQUIRES i2c_bus esp_timer driver)
+                    REQUIRES esp_timer driver)

--- a/ads101x.c
+++ b/ads101x.c
@@ -110,6 +110,7 @@ esp_err_t ads101x_init(ads101x_t *const me, ads101x_model_t model, gpio_num_t in
 	me->is_complete = false;
 	me->int_pin = int_pin;
 	me->use_interrupt = use_interrupt;
+	me->i2c_dev = NULL;
 
 	/* Add device to I2C bus */
 	i2c_device_config_t i2c_dev_conf = {
@@ -119,6 +120,7 @@ esp_err_t ads101x_init(ads101x_t *const me, ads101x_model_t model, gpio_num_t in
 
 	if (i2c_master_bus_add_device(i2c_bus_handle, &i2c_dev_conf, &me->i2c_dev) != ESP_OK) {
 		ESP_LOGE(TAG, "Failed to add device to I2C bus");
+		me->i2c_dev = NULL;
 		return ret;
 	}
 
@@ -136,13 +138,18 @@ esp_err_t ads101x_init(ads101x_t *const me, ads101x_model_t model, gpio_num_t in
 		gpio_isr_handler_add(me->int_pin, isr_handler, (void *)me);
 	}
 
+	/* a transaction to check if the device is ok */
+	if (ads101x_conversion_complete(me) != ESP_OK) {
+		i2c_master_bus_rm_device(me->i2c_dev);
+		ESP_LOGE(TAG, "Failed to initialize device, check wiring and power supply");
+		return ESP_FAIL;
+	}
 	/* Print successful initialization message */
 	ESP_LOGI(TAG, "Instance initialized successfully");
 
 	/* Return ESP_OK */
 	return ret;
 }
-
 /**
  * @brief Function that reads a specific single-ended ADC channel.
  */

--- a/include/ads101x.h
+++ b/include/ads101x.h
@@ -165,6 +165,7 @@ typedef struct {
 	uint8_t bit_shift;
 	gpio_num_t int_pin;
 	bool is_complete;
+	bool use_interrupt;
 } ads101x_t;
 
 /* Exported variables --------------------------------------------------------*/
@@ -183,7 +184,7 @@ typedef struct {
  * @return ESP_OK on success
  */
 esp_err_t ads101x_init(ads101x_t *const me, ads101x_model_t model, gpio_num_t int_pin,
-		i2c_master_bus_handle_t i2c_bus_handle, uint8_t dev_addr);
+		i2c_master_bus_handle_t i2c_bus_handle, uint8_t dev_addr, bool use_interrupt);
 
 /**
  * @brief Function that reads a specific single-ended ADC channel.
@@ -333,12 +334,10 @@ esp_err_t ads101x_start_reading(ads101x_t *const me, uint16_t mux,
  * @brief Function that check if the ADC reading is complete
  *
  * @param me          : Pointer to a ads101x_t instance
- * @param is_complete : Pointer to value to indicate if a ADC conversion is
- *                      complete
  *
  * @return ESP_OK on success
  */
-esp_err_t ads101x_conversion_complete(ads101x_t *const me, bool *is_complete);
+esp_err_t ads101x_conversion_complete(ads101x_t *const me);
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Thanks for the driver man. You saved me a ton of time. I made some changes to make interupt optional as all I have going to my adc1015 is i2c.

Feel free to refuse or heavily tweak this PR as I did add an include for FreeRTOS which works in my project but not sure its done right.

Added the ability to use or not interrupts for all conversions. streamlined the logic that checks for end of conversion for all functions. replaced the custom delay function with the freertos one. We could make this optional but when running on freertos, its better to use vTaskDelay to yield the processor.

Also, should consider blocking on a mutex instead of busy waiting when using interupts as it would also allow yielding the processor until the mutex is released by the isr.